### PR TITLE
Fixed 'Monitoring' title alignment in the notes

### DIFF
--- a/.banzaicloud/charts/spotguide-spark/templates/NOTES.txt
+++ b/.banzaicloud/charts/spotguide-spark/templates/NOTES.txt
@@ -274,6 +274,7 @@ To access logs created by your spark job, we are using spark history server whic
 
 
 {{- if .Values.spark.monitoring.enabled}}
+
 ### Monitoring
 
 The monitoring dashboard can be accessed on the following host:


### PR DESCRIPTION
The Monitoring title wasn't rendered properly on the spotguide summary page